### PR TITLE
[Firefox] 구글 서버를 이용하여 1080p 우회

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -31,6 +31,7 @@
     "webRequestBlocking",
     "storage",
     "https://*.twitch.tv/*",
-    "https://usher.ttvnw.net/*"
+    "https://usher.ttvnw.net/*",
+    "https://*.abs.hls.ttvnw.net/*"
   ]
 }

--- a/firefox/src/background.js
+++ b/firefox/src/background.js
@@ -34,3 +34,14 @@ browser.runtime.onInstalled.addListener(() => {
     serverURL: 'workers.twitch-relay.wesub.io',
   })
 })
+
+browser.webRequest.onBeforeRequest.addListener(
+  async (details) => {
+    const googleProxy = 'www-opensocial.googleusercontent.com/gadgets/proxy?container=focus&url='
+    return new Promise(resolve => resolve({
+      redirectUrl: `https://${googleProxy}${details.url}`,
+    }));
+  },
+  { urls: ['https://*.abs.hls.ttvnw.net/*'] },
+  ['blocking']
+);


### PR DESCRIPTION

구글 서버를 통해 twitch 영상을 가져오도록 하여

1080p 재생을 가능도록 하였습니다.

![스크린샷_20230118_032726](https://user-images.githubusercontent.com/39121933/212981327-741a22a4-f5eb-4f8d-983b-40ef8f701e6a.png)



## 참고 자료

https://gist.github.com/czottmann/5379498




